### PR TITLE
Throttle map service request warn to 1/sec

### DIFF
--- a/src/loc2d_ros.cpp
+++ b/src/loc2d_ros.cpp
@@ -69,7 +69,7 @@ lama::Loc2DROS::Loc2DROS()
     nav_msgs::GetMap::Request  req;
     nav_msgs::GetMap::Response resp;
     while(ros::ok() and not ros::service::call("static_map", req, resp)){
-        ROS_WARN("Request for map failed; trying again ...");
+        ROS_WARN_THROTTLE(1, "Request for map failed; trying again ...");
         ros::Duration d(0.5);
         d.sleep();
     }// end while
@@ -310,4 +310,3 @@ int main(int argc, char *argv[])
 
     return 0;
 }
-


### PR DESCRIPTION
Hi @eupedrosa!

Thanks for, what looks like a very cool package! I'm currently in the process of testing iris_lama and so far so good!

I noticed that the localization node is quite aggressive with warnings while waiting for a map. In this PR I suggest to bring it down by half a second more by using ROS_WARN_THROTTLE. 