### PR TITLE
Filter tf

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ endif()
 find_package(Eigen3 REQUIRED NO_MODULE)
 # find_package(iris_lama REQUIRED)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/include/lama/ros/pf_slam2d_ros.h
+++ b/include/lama/ros/pf_slam2d_ros.h
@@ -53,6 +53,8 @@
 #include <nav_msgs/OccupancyGrid.h>
 #include <nav_msgs/GetMap.h>
 
+#include <Eigen/StdVector>
+
 #include <lama/pose3d.h>
 #include <lama/pf_slam2d.h>
 
@@ -60,6 +62,7 @@ namespace lama {
 
 class PFSlam2DROS {
 public:
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
     PFSlam2DROS();
     ~PFSlam2DROS();
@@ -107,7 +110,7 @@ private:
     // allow to handle multiple lasers at once
     std::map<std::string, int> frame_to_laser_; ///< Map with the known lasers.
     std::vector<bool>          lasers_update_;  ///< Vector that signals which laser to update.
-    std::vector<Pose3D>        lasers_origin_;  ///< Laser origin transformation
+    std::vector<Pose3D, Eigen::aligned_allocator<Pose3D>>        lasers_origin_;  ///< Laser origin transformation
     double max_range_;
 
     // maps

--- a/include/lama/ros/slam2d_ros.h
+++ b/include/lama/ros/slam2d_ros.h
@@ -55,10 +55,13 @@
 #include <lama/slam2d.h>
 #include <lama/pose3d.h>
 
+#include <Eigen/StdVector>
+
 namespace lama {
 
 class Slam2DROS {
 public:
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
     Slam2DROS();
     ~Slam2DROS();
@@ -104,7 +107,7 @@ private:
     // allow to handle multiple lasers at once
     std::map<std::string, int> frame_to_laser_; ///< Map with the known lasers.
     std::vector<bool>          laser_is_reversed_;  ///< Vector that signals if the laser is reversed
-    std::vector<Pose3D>        lasers_origin_;  ///< Laser origin transformation
+    std::vector<Pose3D, Eigen::aligned_allocator<Pose3D>>        lasers_origin_;  ///< Laser origin transformation
     double max_range_;
 
     // maps


### PR DESCRIPTION
Filter `map->odom` transform when playing back bag files. Otherwise we get it published from both the bag file and LaMa SLAM.

I'm happy to make this optional behind a ROS param, but it looks like this is always what we want, since it seems it's only used for the mapping nodes, and it looks to me that it'd be the same if it were used for localization.

On top of https://github.com/iris-ua/iris_lama_ros/pull/12