### PR TITLE
Fix inverted LiDAR support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ endif()
 find_package(Eigen3 REQUIRED NO_MODULE)
 # find_package(iris_lama REQUIRED)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/include/lama/ros/pf_slam2d_ros.h
+++ b/include/lama/ros/pf_slam2d_ros.h
@@ -53,6 +53,8 @@
 #include <nav_msgs/OccupancyGrid.h>
 #include <nav_msgs/GetMap.h>
 
+#include <Eigen/StdVector>
+
 #include <lama/pose3d.h>
 #include <lama/pf_slam2d.h>
 
@@ -60,6 +62,7 @@ namespace lama {
 
 class PFSlam2DROS {
 public:
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
     PFSlam2DROS();
     ~PFSlam2DROS();
@@ -107,7 +110,7 @@ private:
     // allow to handle multiple lasers at once
     std::map<std::string, int> frame_to_laser_; ///< Map with the known lasers.
     std::vector<bool>          lasers_update_;  ///< Vector that signals which laser to update.
-    std::vector<Pose3D>        lasers_origin_;  ///< Laser origin transformation
+    std::vector<Pose3D, Eigen::aligned_allocator<Pose3D>>        lasers_origin_;  ///< Laser origin transformation
     double max_range_;
 
     // maps

--- a/include/lama/ros/slam2d_ros.h
+++ b/include/lama/ros/slam2d_ros.h
@@ -106,7 +106,6 @@ private:
     // == Laser stuff ==
     // allow to handle multiple lasers at once
     std::map<std::string, int> frame_to_laser_; ///< Map with the known lasers.
-    std::vector<bool>          laser_is_reversed_;  ///< Vector that signals if the laser is reversed
     std::vector<Pose3D, Eigen::aligned_allocator<Pose3D>>        lasers_origin_;  ///< Laser origin transformation
     double max_range_;
 

--- a/include/lama/ros/slam2d_ros.h
+++ b/include/lama/ros/slam2d_ros.h
@@ -55,10 +55,13 @@
 #include <lama/slam2d.h>
 #include <lama/pose3d.h>
 
+#include <Eigen/StdVector>
+
 namespace lama {
 
 class Slam2DROS {
 public:
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
     Slam2DROS();
     ~Slam2DROS();
@@ -104,7 +107,7 @@ private:
     // allow to handle multiple lasers at once
     std::map<std::string, int> frame_to_laser_; ///< Map with the known lasers.
     std::vector<bool>          laser_is_reversed_;  ///< Vector that signals if the laser is reversed
-    std::vector<Pose3D>        lasers_origin_;  ///< Laser origin transformation
+    std::vector<Pose3D, Eigen::aligned_allocator<Pose3D>>        lasers_origin_;  ///< Laser origin transformation
     double max_range_;
 
     // maps

--- a/src/pf_slam2d_ros.cpp
+++ b/src/pf_slam2d_ros.cpp
@@ -152,8 +152,10 @@ void lama::PFSlam2DROS::onLaserScan(const sensor_msgs::LaserScanConstPtr& laser_
         catch(tf::TransformException& e)
         { ROS_ERROR("Could not find origin of %s", laser_scan->header.frame_id.c_str()); return; }
 
+        double roll, pitch, yaw;
+        laser_origin.getBasis().getRPY(roll, pitch, yaw);
         Pose3D lp(laser_origin.getOrigin().x(), laser_origin.getOrigin().y(), 0,
-                  0, 0, tf::getYaw(laser_origin.getRotation()));
+                  roll, pitch, yaw);
 
         lasers_origin_.push_back( lp );
 


### PR DESCRIPTION
Fix inverted LiDAR support

With a correct URDF transform specification there's no need to have special logic to detect whether the LiDAR is inverted/reversed or not, i.e. whether the z-axis is point up or down. This information is in the roll, which wasn't used to set the `laser_origin`. This change also takes the pitch into account.

I'm happy to add a check to verify the LiDAR is still in a plane parallel to the floor, i.e. the XY plane, since I believe any other plane is not supported. In practice that means these two conditions should be satisfied:
* `roll == 0.0 || roll == M_PI`
* `pitch == 0.0`

On top of https://github.com/iris-ua/iris_lama_ros/pull/13