### PR TITLE
Add the publishers' queue length as a parameter when replaying offline

### DIFF
--- a/src/offline_replay.cpp
+++ b/src/offline_replay.cpp
@@ -47,6 +47,8 @@ void lama::ReplayRosbag(ros::NodeHandle& pnh, const std::string& rosbag_filename
 {
     std::string scan_topic;
     pnh.param("scan_topic", scan_topic, std::string("/scan"));
+    int queue_length;
+    pnh.param("queue_length", queue_length, 100);
 
     ROS_INFO("Scan topic: %s", scan_topic.c_str());
 
@@ -59,10 +61,10 @@ void lama::ReplayRosbag(ros::NodeHandle& pnh, const std::string& rosbag_filename
         ROS_FATAL("Unable to open rosbag [%s]: %s", rosbag_filename.c_str(), ex.what());
     }
 
-    auto pub_scan  = pnh.advertise<sensor_msgs::LaserScan>(scan_topic,10);
-    auto pub_tf  = pnh.advertise<tf2_msgs::TFMessage>("/tf",10);
-    auto pub_tf_static  = pnh.advertise<tf2_msgs::TFMessage>("/tf_static",10, true);
-    auto pub_clock = pnh.advertise<rosgraph_msgs::Clock>("/clock",10);
+    auto pub_scan  = pnh.advertise<sensor_msgs::LaserScan>(scan_topic, queue_length);
+    auto pub_tf  = pnh.advertise<tf2_msgs::TFMessage>("/tf", queue_length);
+    auto pub_tf_static  = pnh.advertise<tf2_msgs::TFMessage>("/tf_static", queue_length, true);
+    auto pub_clock = pnh.advertise<rosgraph_msgs::Clock>("/clock", queue_length);
 
     ROS_INFO("Allow time for the subscribers to connect");
     ros::WallDuration wait(2); wait.sleep();


### PR DESCRIPTION
### Why
Having a small queue can lead to message drops if the algorithm is not able to process the messages as fast as the publisher publishes them.

### Summary
I was having a lot of trouble reproducing a map that I created from its recorded bag. In reality, I could perform a proper loop- closure, but every time I tried to reconstruct the map from the bag it would fail to close. By increasing the queue the problem (almost) went away.

Result with queue size 10
![image](https://user-images.githubusercontent.com/5129986/99659885-d6de0180-2a61-11eb-8e69-89360ca8ff59.png)

Result with queue size 100
![image](https://user-images.githubusercontent.com/5129986/99660512-c11d0c00-2a62-11eb-9f83-c42f3f4bbd38.png)

Both of the above were initialized with the same random seed. But this raises another question (likely a subject for an issue), why do multiple runs with the same seed produce different results?

### Comment
This might explain the good-humored comment asking if it matters to use that `rate.sleep` instruction to get around the tf jumps.