### PR TITLE
Enable TCP_NODELAY for LaserScan subscribers

### DIFF
--- a/src/loc2d_ros.cpp
+++ b/src/loc2d_ros.cpp
@@ -57,7 +57,7 @@ lama::Loc2DROS::Loc2DROS()
     // Setup subscribers
     // Syncronized LaserScan messages with odometry transforms. This ensures that an odometry transformation
     // exists when the handler of a LaserScan message is called.
-    laser_scan_sub_    = new message_filters::Subscriber<sensor_msgs::LaserScan>(nh_, scan_topic_, 100);
+    laser_scan_sub_    = new message_filters::Subscriber<sensor_msgs::LaserScan>(nh_, scan_topic_, 100, ros::TransportHints().tcpNoDelay());
     laser_scan_filter_ = new tf::MessageFilter<sensor_msgs::LaserScan>(*laser_scan_sub_, *tf_, odom_frame_id_, 100);
     laser_scan_filter_->registerCallback(boost::bind(&Loc2DROS::onLaserScan, this, _1));
 

--- a/src/pf_slam2d_ros.cpp
+++ b/src/pf_slam2d_ros.cpp
@@ -102,7 +102,7 @@ lama::PFSlam2DROS::PFSlam2DROS()
 
     // Syncronized LaserScan messages with odometry transforms. This ensures that an odometry transformation
     // exists when the handler of a LaserScan message is called.
-    laser_scan_sub_    = new message_filters::Subscriber<sensor_msgs::LaserScan>(nh_, scan_topic_, 100);
+    laser_scan_sub_    = new message_filters::Subscriber<sensor_msgs::LaserScan>(nh_, scan_topic_, 100, ros::TransportHints().tcpNoDelay());
     laser_scan_filter_ = new tf::MessageFilter<sensor_msgs::LaserScan>(*laser_scan_sub_, *tf_, odom_frame_id_, 100);
     laser_scan_filter_->registerCallback(boost::bind(&PFSlam2DROS::onLaserScan, this, _1));
 

--- a/src/slam2d_ros.cpp
+++ b/src/slam2d_ros.cpp
@@ -87,7 +87,7 @@ lama::Slam2DROS::Slam2DROS()
 
     // Syncronized LaserScan messages with odometry transforms. This ensures that an odometry transformation
     // exists when the handler of a LaserScan message is called.
-    laser_scan_sub_    = new message_filters::Subscriber<sensor_msgs::LaserScan>(nh_, scan_topic_, 100);
+    laser_scan_sub_    = new message_filters::Subscriber<sensor_msgs::LaserScan>(nh_, scan_topic_, 100, ros::TransportHints().tcpNoDelay());
     laser_scan_filter_ = new tf::MessageFilter<sensor_msgs::LaserScan>(*laser_scan_sub_, *tf_, odom_frame_id_, 100);
     laser_scan_filter_->registerCallback(boost::bind(&Slam2DROS::onLaserScan, this, _1));
 


### PR DESCRIPTION
### Why
TCP_NODELAY tends to reduce the latency when transmitting large messages at high rates.

### Summary
I have noticed a significant improvement in repeatability by enabling `TCP_NODELAY`, especially when reconstructing maps from bag files. I cannot share the bags because they are from a private database, but maybe the following reports can aid the discussion.

Report ***without*** `TCP_NODELAY`
```
LaMa PF Slam2D - Report
 =======================
 Number of updates     1811
 Number of resamples   29
 Max memory usage      127.62 MiB
 Problem time span     29 minute(s) and 58 second(s)
 Execution time span   1 minute(s) and 58 second(s)
 Execution frequency   15.24 Hz
 Realtime factor       15.14x

 Execution time (mean ± std [min, max]) in milliseconds
 --------------------------------------------------------
 Update          65.624493 ± 24.572288 [16.365688, 204.315101]
   Optimization  15.406339 ± 6.583668 [4.105412, 64.503286]
   Normalizing   0.003712 ± 0.014701 [0.001416, 0.626481]
   Resampling    48.198855 ± 23.639840 [14.698563, 93.370426]
   Mapping       49.428003 ± 21.123442 [8.296447, 142.351808]
```

Report ***with*** `TCP_NODELAY`
```
 LaMa PF Slam2D - Report
 =======================
 Number of updates     1808
 Number of resamples   25
 Max memory usage      130.31 MiB
 Problem time span     29 minute(s) and 58 second(s)
 Execution time span   1 minute(s) and 54 second(s)
 Execution frequency   15.73 Hz
 Realtime factor       15.65x

 Execution time (mean ± std [min, max]) in milliseconds
 --------------------------------------------------------
 Update          63.586018 ± 23.778238 [13.311249, 168.210410]
   Optimization  14.644808 ± 5.956713 [3.533703, 57.413043]
   Normalizing   0.003259 ± 0.001786 [0.001344, 0.061546]
   Resampling    45.279249 ± 20.000452 [10.625678, 86.464556]
   Mapping       48.296392 ± 20.920238 [8.375613, 129.647679]
```

Multiple runs slightly change the memory usage and number of updates but have little impact on the execution time statistics.