### PR TITLE
Add the option to subscribe to the /map topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,5 +108,6 @@ Please use `rviz` to set the initial pose. Global localization is not yet implem
 * `~l2_max`: Maximum distance to use in the dynamic Euclidean distance map (default: 0.5 meters).
 * `~strategy`: Scan matching optimization strategy, GaussNewton ("gm") or Levenberg Marquard ("lm") (default: "gn").
 * `~patch_size`: Length of a patch (default: 32 cells).
-
-
+* `~use_map_topic`: True to subscribe to the `/map` topic instead of requesting the map through the "`static_map`" service (default: `false`).
+* `~first_map_only`: True to use only the first map ever received (default: `false`).
+* `~use_pose_on_new_map`: True to use the current algorithm pose when the map changes (default: `false`).

--- a/include/lama/ros/loc2d_ros.h
+++ b/include/lama/ros/loc2d_ros.h
@@ -67,6 +67,10 @@ public:
 
     void onInitialPose(const geometry_msgs::PoseWithCovarianceStampedConstPtr& initial_pose);
     void onLaserScan(const sensor_msgs::LaserScanConstPtr& laser_scan);
+    void onMapReceived(const nav_msgs::OccupancyGridConstPtr& msg)
+    {
+        InitLoc2DFromOccupancyGridMsg(*msg);
+    }
 
     //bool onGetMap(nav_msgs::GetMap::Request &req, nav_msgs::GetMap::Response &res);
 
@@ -96,6 +100,7 @@ private:
 
     // Subscribers
     ros::Subscriber pose_sub_;   ///< Subscriber of the initial pose (with covariance)
+    ros::Subscriber map_sub_; ///< Subscriber of the map; used if \p use_map_topic_ is true.
 
     // == Laser stuff ==
     // Handle multiple lasers at once
@@ -109,6 +114,8 @@ private:
     std::string base_frame_id_;         ///< Robot base frame.
 
     std::string scan_topic_;   ///< LaserScan message topic.
+
+    bool use_map_topic_; ///< True to subscribe to the map topic instead of requesting the map through the "static_map" service
 
     // == Inner state ==
     Loc2D   loc2d_;

--- a/include/lama/ros/loc2d_ros.h
+++ b/include/lama/ros/loc2d_ros.h
@@ -67,16 +67,18 @@ public:
 
     void onInitialPose(const geometry_msgs::PoseWithCovarianceStampedConstPtr& initial_pose);
     void onLaserScan(const sensor_msgs::LaserScanConstPtr& laser_scan);
-    void onMapReceived(const nav_msgs::OccupancyGridConstPtr& msg)
-    {
-        InitLoc2DFromOccupancyGridMsg(*msg);
-    }
+    void onMapReceived(const nav_msgs::OccupancyGridConstPtr& msg);
 
     //bool onGetMap(nav_msgs::GetMap::Request &req, nav_msgs::GetMap::Response &res);
 
 private:
 
-    void InitLoc2DFromOccupancyGridMsg(const nav_msgs::OccupancyGrid& msg);
+    void InitLoc2DFromOccupancyGridMsg(const nav_msgs::OccupancyGrid& msg)
+    {
+        InitLoc2DFromOccupancyGridMsg(initial_prior_, msg);
+    }
+
+    void InitLoc2DFromOccupancyGridMsg(const Pose2D& prior, const nav_msgs::OccupancyGrid& msg);
 
     bool initLaser(const sensor_msgs::LaserScanConstPtr& laser_scan);
 
@@ -116,10 +118,13 @@ private:
     std::string scan_topic_;   ///< LaserScan message topic.
 
     bool use_map_topic_; ///< True to subscribe to the map topic instead of requesting the map through the "static_map" service
+    bool use_pose_on_new_map_; ///< True to use the current algorithm pose when the map changes
 
     // == Inner state ==
     Loc2D   loc2d_;
     Pose2D odom_;
+    Loc2D::Options options_;
+    Pose2D initial_prior_;
 };
 
 } /* lama */

--- a/include/lama/ros/loc2d_ros.h
+++ b/include/lama/ros/loc2d_ros.h
@@ -118,6 +118,8 @@ private:
     std::string scan_topic_;   ///< LaserScan message topic.
 
     bool use_map_topic_; ///< True to subscribe to the map topic instead of requesting the map through the "static_map" service
+    bool first_map_only_; ///< True to use only the first map ever received
+    bool first_map_received_; ///< True if the first map has already been received
     bool use_pose_on_new_map_; ///< True to use the current algorithm pose when the map changes
 
     // == Inner state ==

--- a/src/loc2d_ros.cpp
+++ b/src/loc2d_ros.cpp
@@ -51,6 +51,7 @@ lama::Loc2DROS::Loc2DROS()
     pnh_.param("transform_tolerance", tmp, 0.1); transform_tolerance_.fromSec(tmp);
 
     pnh_.param("use_map_topic", use_map_topic_, false);
+    pnh_.param("first_map_only", first_map_only_, false);
     pnh_.param("use_pose_on_new_map", use_pose_on_new_map_, false);
 
     // Setup TF workers ...
@@ -230,7 +231,10 @@ void lama::Loc2DROS::onLaserScan(const sensor_msgs::LaserScanConstPtr& laser_sca
 
 void lama::Loc2DROS::onMapReceived(const nav_msgs::OccupancyGridConstPtr& msg)
 {
+    if (first_map_only_ and first_map_received_)
+        return;
     InitLoc2DFromOccupancyGridMsg(use_pose_on_new_map_ ? loc2d_.getPose() : initial_prior_, *msg);
+    first_map_received_ = true;
 }
 
 void lama::Loc2DROS::InitLoc2DFromOccupancyGridMsg(const Pose2D& prior, const nav_msgs::OccupancyGrid& msg)

--- a/src/loc2d_ros.cpp
+++ b/src/loc2d_ros.cpp
@@ -51,6 +51,7 @@ lama::Loc2DROS::Loc2DROS()
     pnh_.param("transform_tolerance", tmp, 0.1); transform_tolerance_.fromSec(tmp);
 
     pnh_.param("use_map_topic", use_map_topic_, false);
+    pnh_.param("use_pose_on_new_map", use_pose_on_new_map_, false);
 
     // Setup TF workers ...
     tf_ = new tf::TransformListener();
@@ -68,6 +69,18 @@ lama::Loc2DROS::Loc2DROS()
     // Set publishers
     pose_pub_ = nh_.advertise<geometry_msgs::PoseWithCovarianceStamped>("/pose", 10);
 
+    // Fetch algorithm options
+    Vector2d pos; double init_a;
+    pnh_.param("initial_pos_x", pos[0], 0.0);
+    pnh_.param("initial_pos_y", pos[1], 0.0);
+    pnh_.param("initial_pos_a", init_a, 0.0);
+    initial_prior_ = lama::Pose2D(pos, init_a);
+
+    pnh_.param("d_thresh", options_.trans_thresh, 0.01);
+    pnh_.param("a_thresh", options_.rot_thresh, 0.2);
+    pnh_.param("l2_max",   options_.l2_max, 0.5);
+    pnh_.param("strategy", options_.strategy, std::string("gn"));
+
     // Request the map if not using the map topic
     if (not use_map_topic_)
     {
@@ -80,7 +93,11 @@ lama::Loc2DROS::Loc2DROS()
             d.sleep();
         }// end while
 
-        InitLoc2DFromOccupancyGridMsg(resp.map);
+        int itmp;
+        pnh_.param("patch_size", itmp, 32);
+        options_.patch_size = itmp;
+
+        InitLoc2DFromOccupancyGridMsg(initial_prior_, resp.map);
     }
     else
     {
@@ -211,38 +228,27 @@ void lama::Loc2DROS::onLaserScan(const sensor_msgs::LaserScanConstPtr& laser_sca
     } // end if (update)
 }
 
-void lama::Loc2DROS::InitLoc2DFromOccupancyGridMsg(const nav_msgs::OccupancyGrid& msg)
+void lama::Loc2DROS::onMapReceived(const nav_msgs::OccupancyGridConstPtr& msg)
 {
-    Vector2d pos; double tmp;
-    pnh_.param("initial_pos_x", pos[0], 0.0);
-    pnh_.param("initial_pos_y", pos[1], 0.0);
-    pnh_.param("initial_pos_a", tmp, 0.0);
-    lama::Pose2D prior(pos, tmp);
+    InitLoc2DFromOccupancyGridMsg(use_pose_on_new_map_ ? loc2d_.getPose() : initial_prior_, *msg);
+}
 
-    Loc2D::Options options;
-    pnh_.param("d_thresh", options.trans_thresh, 0.01);
-    pnh_.param("a_thresh", options.rot_thresh, 0.2);
-    pnh_.param("l2_max",   options.l2_max, 0.5);
-    pnh_.param("strategy", options.strategy, std::string("gn"));
-
-    int itmp;
-    pnh_.param("patch_size", itmp, 32);
-    options.patch_size = itmp;
-
-    options.resolution = msg.info.resolution;
-
-    loc2d_.Init(options);
+void lama::Loc2DROS::InitLoc2DFromOccupancyGridMsg(const Pose2D& prior, const nav_msgs::OccupancyGrid& msg)
+{
+    options_.resolution = msg.info.resolution;
+    loc2d_.Init(options_);
     loc2d_.setPose(prior);
 
     ROS_INFO("Localization parameters: d_thresh: %.2f, a_thresh: %.2f, l2_max: %.2f",
-             options.trans_thresh, options.rot_thresh, options.l2_max);
+             options_.trans_thresh, options_.rot_thresh, options_.l2_max);
 
     unsigned int width = msg.info.width;
     unsigned int height= msg.info.height;
 
     for (unsigned int j = 0; j < height; ++j)
-        for (unsigned int i = 0; i < width;  ++i){
-
+    {
+        for (unsigned int i = 0; i < width;  ++i)
+        {
             Vector3d coords;
             coords.x() = msg.info.origin.position.x + i * msg.info.resolution;
             coords.y() = msg.info.origin.position.y + j * msg.info.resolution;
@@ -254,7 +260,8 @@ void lama::Loc2DROS::InitLoc2DFromOccupancyGridMsg(const nav_msgs::OccupancyGrid
                 loc2d_.occupancy_map->setOccupied(coords);
                 loc2d_.distance_map->addObstacle(loc2d_.distance_map->w2m(coords));
             }
-        }// end for
+        }
+    }
 
     loc2d_.distance_map->update();
 }


### PR DESCRIPTION
## Why
This functionality was missing, and it is nice to have for users wishing to try this as a replacement to other localization solutions, such as http://wiki.ros.org/amcl.

For compatibility, the default is to call the `static_map` service.

## New parameters with default values
``` .yaml
use_map_topic: false
first_map_only: false
use_pose_on_new_map: false
```