### PR TITLE
[localization] add the option to trigger an update without motion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ find_package(catkin REQUIRED COMPONENTS
     visualization_msgs
     rosbag_storage
     iris_lama
+    std_srvs
 )
 
 catkin_package()

--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ rosrun iris_lama_ros loc2d_ros scan:=base_scan
 ```
 Please use `rviz` to set the initial pose. Global localization is not yet implemented.
 
+### Services
+
+* `/request_nomotion_update`: Called to trigger an update without moving the robot (no-motion update)
 ### Parameters
 
 * `~global_frame_id`: The frame attached to the map (default: "map").
@@ -111,3 +114,4 @@ Please use `rviz` to set the initial pose. Global localization is not yet implem
 * `~use_map_topic`: True to subscribe to the `/map` topic instead of requesting the map through the "`static_map`" service (default: `false`).
 * `~first_map_only`: True to use only the first map ever received (default: `false`).
 * `~use_pose_on_new_map`: True to use the current algorithm pose when the map changes (default: `false`).
+* `~force_update_on_initial_pose`: True to trigger a no-motion update when an initial pose is received (default: `false`)

--- a/include/lama/ros/loc2d_ros.h
+++ b/include/lama/ros/loc2d_ros.h
@@ -68,6 +68,7 @@ public:
     ~Loc2DROS();
 
     void onInitialPose(const geometry_msgs::PoseWithCovarianceStampedConstPtr& initial_pose);
+    void onInitialPose(const Pose2D& prior);
     void onLaserScan(const sensor_msgs::LaserScanConstPtr& laser_scan);
     void onMapReceived(const nav_msgs::OccupancyGridConstPtr& msg);
 
@@ -114,6 +115,7 @@ private:
 
     // Service providers
     ros::ServiceServer srv_update_; ///< Service to trigger a scan match
+
     // == Laser stuff ==
     // Handle multiple lasers at once
     std::map<std::string, int> frame_to_laser_; ///< Map with the known lasers.
@@ -132,6 +134,7 @@ private:
     bool first_map_received_; ///< True if the first map has already been received
     bool use_pose_on_new_map_; ///< True to use the current algorithm pose when the map changes
     bool force_update_; ///< True to force an update when a new laser scan is received
+    bool force_update_on_initial_pose_; ///< True to trigger a forced updated when an initial pose is received
 
     // == Inner state ==
     Loc2D   loc2d_;

--- a/include/lama/ros/loc2d_ros.h
+++ b/include/lama/ros/loc2d_ros.h
@@ -50,6 +50,8 @@
 #include <sensor_msgs/LaserScan.h>
 // maps
 #include <nav_msgs/OccupancyGrid.h>
+// Force triggering a no-motion update
+#include <std_srvs/Empty.h>
 
 #include <lama/pose3d.h>
 #include <lama/loc2d.h>
@@ -82,6 +84,12 @@ private:
 
     bool initLaser(const sensor_msgs::LaserScanConstPtr& laser_scan);
 
+    bool onTriggerUpdate(std_srvs::Empty::Request&, std_srvs::Empty::Response&)
+    {
+        force_update_ = true;
+        return true;
+    }
+
 private:
 
     // == ROS stuff ==
@@ -104,6 +112,8 @@ private:
     ros::Subscriber pose_sub_;   ///< Subscriber of the initial pose (with covariance)
     ros::Subscriber map_sub_; ///< Subscriber of the map; used if \p use_map_topic_ is true.
 
+    // Service providers
+    ros::ServiceServer srv_update_; ///< Service to trigger a scan match
     // == Laser stuff ==
     // Handle multiple lasers at once
     std::map<std::string, int> frame_to_laser_; ///< Map with the known lasers.
@@ -121,6 +131,7 @@ private:
     bool first_map_only_; ///< True to use only the first map ever received
     bool first_map_received_; ///< True if the first map has already been received
     bool use_pose_on_new_map_; ///< True to use the current algorithm pose when the map changes
+    bool force_update_; ///< True to force an update when a new laser scan is received
 
     // == Inner state ==
     Loc2D   loc2d_;

--- a/package.xml
+++ b/package.xml
@@ -24,6 +24,7 @@
     <build_depend>message_filters</build_depend>
     <build_depend>visualization_msgs</build_depend>
     <build_depend>iris_lama</build_depend>
+    <build_depend>std_srvs</build_depend>
 
     <run_depend>tf</run_depend>
     <run_depend>roscpp</run_depend>
@@ -35,6 +36,7 @@
     <run_depend>message_filters</run_depend>
     <run_depend>visualization_msgs</run_depend>
     <run_depend>iris_lama</run_depend>
+    <run_depend>std_srvs</run_depend>
 
     <export />
 


### PR DESCRIPTION
### Why
Some users (like myself) might need this feature when migrating from AMCL.

### Summary
In AMCL this feature is exposed in the service `request_nomotion_update` with type `std_srvs/Empty`. So, I've implemented the same API to keep it consistent. Besides, I've also added a parameter `force_update_on_initial_pose` to (guess what) force an update when an initial pose is received.