### PR TITLE
Fix laser orientation problem

### DIFF
--- a/include/lama/ros/loc2d_ros.h
+++ b/include/lama/ros/loc2d_ros.h
@@ -120,7 +120,6 @@ private:
     // == Laser stuff ==
     // Handle multiple lasers at once
     std::map<std::string, int> frame_to_laser_; ///< Map with the known lasers.
-    std::vector<bool>          laser_is_reversed_;;  ///< Vector that signals if the laser is reversed
     std::vector<Pose3D>        lasers_origin_;  ///< Laser origin transformation
 
     // == configuration variables ==


### PR DESCRIPTION
It is the robot's owner's responsibility to enter laser orientation correctly in the urdf.

I understand that this parts were taken from slam_gmapping but there's no need for these checks since tf already has everything needed.

I tried running `loc2d_ros` node on my robot which has its laser mounted downwards. It updated robot's position towards wrong direction when the robot was turning around. So I fixed the code.

After that, I tried with another robot which has a normal laser mounted upwards. This way it works on both without any configuration or checks.

Also, just a reminder, your Noetic package (`ros-noetic-iris-lama-ros`) doesn't work. But the master branch (with this commit) works ok.
