### PR TITLE
Support for ROS 2 jazzy

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Overview
 
 ROS integration of [LaMa]( https://github.com/iris-ua/iris_lama), a Localization and Mapping package from the **Intelligent Robotics and Systems** (IRIS) Laboratory, University of Aveiro. It provides 2D Localization and SLAM. It works great on a [TurtleBot2](https://www.turtlebot.com/turtlebot2/) with a [Raspberry Pi 3 Model B+](https://www.raspberrypi.org/products/raspberry-pi-3-model-b-plus/) and an Hokuyo (Rapid URG). It also works on a simulated [TurtleBot3](http://emanual.robotis.com/docs/en/platform/turtlebot3/ros2_setup/).
 
-#### Environment
+#### Environment (for ROS 2 Eloquent, not Jazzy)
 
 Use Docker if you want a containerized environment. A `Dockerfile` is supplied. If you are on an office network that blocks Google's DNS servers, [configure](https://stackoverflow.com/questions/44184496/configuring-options-for-docker-run/44184773#44184773) your DNS. It should be as simple as editing `/etc/docker/daemon.json` with your office's [DNS server](https://www.tecmint.com/find-my-dns-server-ip-address-in-linux/). 
 
@@ -32,13 +32,13 @@ cd dev_ws/src
 git clone https://github.com/iris-ua/iris_lama
 git clone https://github.com/iris-ua/iris_lama_ros
 cd iris_lama_ros
-git checkout eloquent-devel
+git checkout jazzy-devel
 cd ../ss
 colcon build
 . install/setup.bash
 ```
 
-The build was tested in the provided Dockerfile with **Ubuntu 18.04** and **ROS2 Eloquent**.
+The build was tested on **Ubuntu 24.04** and **ROS2 Jazzy**.
 
 ## SLAM nodes
 

--- a/include/lama/ros/lama_utils.h
+++ b/include/lama/ros/lama_utils.h
@@ -7,9 +7,9 @@
 
 #include "rclcpp/rclcpp.hpp"
 #include <tf2_ros/message_filter.h>
-#include "tf2_geometry_msgs/tf2_geometry_msgs.h"
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 #include "tf2/transform_datatypes.h"
-#include <tf2_sensor_msgs/tf2_sensor_msgs.h>
+#include "tf2_sensor_msgs/tf2_sensor_msgs.hpp"
 
 namespace lama_utils {
 

--- a/include/lama/ros/loc2d_ros.h
+++ b/include/lama/ros/loc2d_ros.h
@@ -52,8 +52,8 @@
 // maps
 #include "nav_msgs/msg/occupancy_grid.hpp"
 #include "nav_msgs/srv/get_map.hpp"
-#include "tf2_geometry_msgs/tf2_geometry_msgs.h"
-#include <tf2_sensor_msgs/tf2_sensor_msgs.h>
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
+#include "tf2_sensor_msgs/tf2_sensor_msgs.hpp"
 
 #include <lama/pose3d.h>
 #include <lama/loc2d.h>

--- a/include/lama/ros/pf_slam2d_ros.h
+++ b/include/lama/ros/pf_slam2d_ros.h
@@ -54,7 +54,7 @@
 #include "nav_msgs/srv/get_map.hpp"
 #include "nav_msgs/msg/path.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
-#include "tf2_geometry_msgs/tf2_geometry_msgs.h"
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 
 #include "lama/ros/lama_utils.h"
 #include <lama/pose3d.h>

--- a/include/lama/ros/slam2d_ros.h
+++ b/include/lama/ros/slam2d_ros.h
@@ -46,7 +46,7 @@
 
 // Pose publishing
 #include "geometry_msgs/msg/pose_with_covariance_stamped.hpp"
-#include "tf2_geometry_msgs/tf2_geometry_msgs.h"
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 
 // Laser message
 #include "sensor_msgs/msg/laser_scan.hpp"

--- a/launch/loc2d_launch.py
+++ b/launch/loc2d_launch.py
@@ -17,9 +17,9 @@ def generate_launch_description():
         #launch.actions.DeclareLaunchArgument('/use_sim_time',  default_value="True", description=''),
         Node(
             package='iris_lama_ros2',
-            node_namespace='iris_lama_ros2',
-            node_executable='loc2d_ros',
-            node_name='loc2d_ros',
+            namespace='iris_lama_ros2',
+            executable='loc2d_ros',
+            name='loc2d_ros',
             #remappings=[
             #    ('/input/pose', '/turtlesim1/turtle1/pose'),
             #    ('/output/cmd_vel', '/turtlesim2/turtle1/cmd_vel')

--- a/launch/pf_slam2d_live_launch.py
+++ b/launch/pf_slam2d_live_launch.py
@@ -17,9 +17,9 @@ def generate_launch_description():
         #launch.actions.DeclareLaunchArgument('/use_sim_time',  default_value="True", description=''),
         Node(
             package='iris_lama_ros2',
-            node_namespace='iris_lama_ros2',
-            node_executable='pf_slam2d_ros',
-            node_name='pf_slam2d_ros',
+            namespace='iris_lama_ros2',
+            executable='pf_slam2d_ros',
+            name='pf_slam2d_ros',
             #remappings=[
             #    ('/input/pose', '/turtlesim1/turtle1/pose'),
             #    ('/output/cmd_vel', '/turtlesim2/turtle1/cmd_vel')

--- a/launch/pf_slam2d_offline_launch.py
+++ b/launch/pf_slam2d_offline_launch.py
@@ -18,9 +18,9 @@ def generate_launch_description():
         #launch.actions.DeclareLaunchArgument('/use_sim_time',  default_value="True", description=''),
         Node(
             package='iris_lama_ros2',
-            node_namespace='iris_lama_ros2',
-            node_executable='pf_slam2d_ros',
-            node_name='pf_slam2d_ros',
+            namespace='iris_lama_ros2',
+            executable='pf_slam2d_ros',
+            name='pf_slam2d_ros',
             #remappings=[
             #    ('/input/pose', '/turtlesim1/turtle1/pose'),
             #    ('/output/cmd_vel', '/turtlesim2/turtle1/cmd_vel')

--- a/launch/slam2d_live_launch.py
+++ b/launch/slam2d_live_launch.py
@@ -17,9 +17,9 @@ def generate_launch_description():
         #launch.actions.DeclareLaunchArgument('/use_sim_time',  default_value="True", description=''),
         Node(
             package='iris_lama_ros2',
-            node_namespace='iris_lama_ros2',
-            node_executable='slam2d_ros',
-            node_name='slam2d_ros',
+            namespace='iris_lama_ros2',
+            executable='slam2d_ros',
+            name='slam2d_ros',
             #remappings=[
             #    ('/input/pose', '/turtlesim1/turtle1/pose'),
             #    ('/output/cmd_vel', '/turtlesim2/turtle1/cmd_vel')

--- a/launch/slam2d_offline_launch.py
+++ b/launch/slam2d_offline_launch.py
@@ -18,9 +18,9 @@ def generate_launch_description():
         #launch.actions.DeclareLaunchArgument('/use_sim_time',  default_value="True", description=''),
         Node(
             package='iris_lama_ros2',
-            node_namespace='iris_lama_ros2',
-            node_executable='slam2d_ros',
-            node_name='slam2d_ros',
+            namespace='iris_lama_ros2',
+            executable='slam2d_ros',
+            name='slam2d_ros',
             #remappings=[
             #    ('/input/pose', '/turtlesim1/turtle1/pose'),
             #    ('/output/cmd_vel', '/turtlesim2/turtle1/cmd_vel')

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,18 +1,20 @@
 add_executable(loc2d_ros loc2d_ros.cpp)
-
 ament_target_dependencies(loc2d_ros
     "tf2" "tf2_sensor_msgs" "tf2_msgs" "tf2_ros" "tf2_geometry_msgs" "rclcpp" "nav_msgs" "sensor_msgs"
-    "geometry_msgs" "message_filters" "visualization_msgs" "rosbag2" "iris_lama")
+    "geometry_msgs" "message_filters" "visualization_msgs" "rosbag2")
+target_link_libraries(loc2d_ros iris_lama::iris_lama)
 
 add_executable(slam2d_ros slam2d_ros.cpp)
 ament_target_dependencies(slam2d_ros
         "Eigen3" "tf2" "tf2_sensor_msgs" "tf2_msgs" "tf2_ros" "tf2_geometry_msgs" "rclcpp" "nav_msgs" "sensor_msgs"
-        "geometry_msgs" "message_filters" "visualization_msgs" "rosbag2" "iris_lama")
+        "geometry_msgs" "message_filters" "visualization_msgs" "rosbag2")
+target_link_libraries(slam2d_ros iris_lama::iris_lama)
 
 add_executable(pf_slam2d_ros pf_slam2d_ros.cpp)
 ament_target_dependencies(pf_slam2d_ros
         "Eigen3" "tf2" "tf2_sensor_msgs" "tf2_msgs" "tf2_ros" "tf2_geometry_msgs" "rclcpp" "nav_msgs" "sensor_msgs"
-        "geometry_msgs" "message_filters" "visualization_msgs" "rosbag2" "iris_lama")
+        "geometry_msgs" "message_filters" "visualization_msgs" "rosbag2")
+target_link_libraries(pf_slam2d_ros iris_lama::iris_lama)
 
 # Install executables
 install(TARGETS loc2d_ros pf_slam2d_ros slam2d_ros

--- a/src/loc2d_ros.cpp
+++ b/src/loc2d_ros.cpp
@@ -39,16 +39,16 @@ lama::Loc2DROS::Loc2DROS(const std::string &name) :
 
     // Load parameters from the server.
     double tmp;
-    node->declare_parameter("global_frame_id");
-    node->get_parameter_or("global_frame_id", global_frame_id_, std::string("map"));
-    node->declare_parameter("odom_frame_id");
-    node->get_parameter_or("odom_frame_id", odom_frame_id_, std::string("odom"));
-    node->declare_parameter("base_frame_id");
-    node->get_parameter_or("base_frame_id", base_frame_id_, std::string("base_link"));
-    node->declare_parameter("scan_topic");
-    node->get_parameter_or("scan_topic", scan_topic_, std::string("/scan"));
-    node->declare_parameter("transform_tolerance");
-    node->get_parameter_or("transform_tolerance", tmp, 0.1);
+    node->declare_parameter("global_frame_id", "map");
+    global_frame_id_ = node->get_parameter("global_frame_id").as_string();
+    node->declare_parameter("odom_frame_id", "odom");
+    odom_frame_id_ = node->get_parameter("odom_frame_id").as_string();
+    node->declare_parameter("base_frame_id", "base_link");
+    base_frame_id_ = node->get_parameter("base_frame_id").as_string();
+    node->declare_parameter("scan_topic", "/scan");
+    scan_topic_ = node->get_parameter("scan_topic").as_string();
+    node->declare_parameter("transform_tolerance", 0.1);
+    tmp = node->get_parameter("transform_tolerance").as_double();
     transform_tolerance_ = rclcpp::Duration::from_seconds(tmp);
 
     loc2d_ = std::make_shared<Loc2D>();
@@ -253,19 +253,27 @@ void lama::Loc2DROS::onLaserScan(sensor_msgs::msg::LaserScan::ConstSharedPtr las
 void lama::Loc2DROS::InitLoc2DFromOccupancyGridMsg(const nav_msgs::msg::OccupancyGrid &msg) {
     Vector2d pos;
     double tmp;
-    node->get_parameter_or("initial_pos_x", pos[0], 0.0);
-    node->get_parameter_or("initial_pos_y", pos[1], 0.0);
-    node->get_parameter_or("initial_pos_a", tmp, 0.0);
+    node->declare_parameter("initial_pos_x", 0.0);
+    pos[0] = node->get_parameter("initial_pos_x").as_double();
+    node->declare_parameter("initial_pos_y", 0.0);
+    pos[1] = node->get_parameter("initial_pos_y").as_double();
+    node->declare_parameter("initial_pos_a", 0.0);
+    tmp = node->get_parameter("initial_pos_a").as_double();
     lama::Pose2D prior(pos, tmp);
 
     Loc2D::Options options;
-    node->get_parameter_or("d_thresh", options.trans_thresh, 0.01);
-    node->get_parameter_or("a_thresh", options.rot_thresh, 0.2);
-    node->get_parameter_or("l2_max", options.l2_max, 0.5);
-    node->get_parameter_or("strategy", options.strategy, std::string("gn"));
+    node->declare_parameter("d_thresh", 0.01);
+    options.trans_thresh = node->get_parameter("d_thresh").as_double();
+    node->declare_parameter("a_thresh", 0.2);
+    options.rot_thresh = node->get_parameter("a_thresh").as_double();
+    node->declare_parameter("l2_max", 0.5);
+    options.l2_max = node->get_parameter("l2_max").as_double();
+    node->declare_parameter("strategy", "gn");
+    options.strategy = node->get_parameter("strategy").as_string();
 
     int itmp;
-    node->get_parameter_or("patch_size", itmp, 32);
+    node->declare_parameter("patch_size", 32);
+    itmp = node->get_parameter("patch_size").as_int();
     options.patch_size = itmp;
 
     options.resolution = msg.info.resolution;

--- a/src/loc2d_ros.cpp
+++ b/src/loc2d_ros.cpp
@@ -84,7 +84,7 @@ lama::Loc2DROS::Loc2DROS(const std::string &name) :
 
     // Wait for the result.
     auto result_future = client->async_send_request(request);
-    if (rclcpp::spin_until_future_complete(node, result_future) == rclcpp::executor::FutureReturnCode::SUCCESS)
+    if (rclcpp::spin_until_future_complete(node, result_future) == rclcpp::FutureReturnCode::SUCCESS)
     {
         RCLCPP_INFO(node->get_logger(), "Got map");
     } else {

--- a/src/pf_slam2d_ros.cpp
+++ b/src/pf_slam2d_ros.cpp
@@ -319,7 +319,7 @@ void lama::PFSlam2DROS::onLaserScan(sensor_msgs::msg::LaserScan::ConstSharedPtr 
         path_pub_->publish(path);
 
         RCLCPP_DEBUG(node->get_logger(), "Update time: %.3fms - NEFF: %.2f",
-                RCUTILS_NS_TO_MS((end-start).nanoseconds()), slam2d_->getNeff());
+                static_cast<double>(RCUTILS_NS_TO_MS((end-start).nanoseconds())), slam2d_->getNeff());
 	RCLCPP_DEBUG(node->get_logger(), "Sent TF Map->Odom");
     } else {
         // Nothing has change, therefore, republish the last transform.
@@ -542,6 +542,7 @@ bool lama::PFSlam2DROS::PatchMsgFromOccupancyMap(nav_msgs::msg::OccupancyGrid &m
 
 void lama::PFSlam2DROS::onGetMap(const std::shared_ptr <nav_msgs::srv::GetMap::Request> req,
                                  std::shared_ptr <nav_msgs::srv::GetMap::Response> res) {
+    static_cast<void>(req);  // To suppress compiler warning
     res->map.header.frame_id = global_frame_id_;
     res->map.header.stamp = ros_clock->now();
 

--- a/src/pf_slam2d_ros.cpp
+++ b/src/pf_slam2d_ros.cpp
@@ -40,81 +40,81 @@ lama::PFSlam2DROS::PFSlam2DROS(std::string name) :
 
     // Load parameters from the server.
     double tmp;
-    node->declare_parameter("global_frame_id");
-    node->get_parameter_or("global_frame_id", global_frame_id_, std::string("map"));
-    node->declare_parameter("odom_frame_id");
-    node->get_parameter_or("odom_frame_id", odom_frame_id_, std::string("odom"));
-    node->declare_parameter("base_frame_id");
-    node->get_parameter_or("base_frame_id", base_frame_id_, std::string("base_link"));
-    node->declare_parameter("scan_topic");
-    node->get_parameter_or("scan_topic", scan_topic_, std::string("/scan"));
-    node->declare_parameter("transform_tolerance");
-    node->get_parameter_or("transform_tolerance", tmp, 0.1);
+    node->declare_parameter("global_frame_id", "map");
+    global_frame_id_ = node->get_parameter("global_frame_id").as_string();
+    node->declare_parameter("odom_frame_id", "odom");
+    odom_frame_id_ = node->get_parameter("odom_frame_id").as_string();
+    node->declare_parameter("base_frame_id", "base_link");
+    base_frame_id_ = node->get_parameter("base_frame_id").as_string();
+    node->declare_parameter("scan_topic", "/scan");
+    scan_topic_ =  node->get_parameter("scan_topic").as_string();
+    node->declare_parameter("transform_tolerance", 0.1);
+    tmp = node->get_parameter("transform_tolerance").as_double();
     transform_tolerance_ = rclcpp::Duration::from_seconds(tmp);
 
     Vector2d pos;
-    node->declare_parameter("initial_pos_x");
-    node->get_parameter_or("initial_pos_x", pos[0], 0.0);
-    node->declare_parameter("initial_pos_y");
-    node->get_parameter_or("initial_pos_y", pos[1], 0.0);
-    node->declare_parameter("initial_pos_a");
-    node->get_parameter_or("initial_pos_a", tmp, 0.0);
+    node->declare_parameter("initial_pos_x", 0.0);
+    pos[0] = node->get_parameter("initial_pos_x").as_double();
+    node->declare_parameter("initial_pos_y", 0.0);
+    pos[1] = node->get_parameter("initial_pos_y").as_double();
+    node->declare_parameter("initial_pos_a", 0.0);
+    tmp = node->get_parameter("initial_pos_a").as_double();
     Pose2D prior(pos, tmp);
 
     PFSlam2D::Options options;
-    node->declare_parameter("srr");
-    node->get_parameter_or("srr", options.srr, 0.1);
-    node->declare_parameter("str");
-    node->get_parameter_or("str", options.str, 0.2);
-    node->declare_parameter("stt");
-    node->get_parameter_or("stt", options.stt, 0.1);
-    node->declare_parameter("srt");
-    node->get_parameter_or("srt", options.srt, 0.2);
-    node->declare_parameter("sigma");
-    node->get_parameter_or("sigma", options.meas_sigma, 0.05);
-    node->declare_parameter("lgain");
-    node->get_parameter_or("lgain", options.meas_sigma_gain, 3.0);
-    node->declare_parameter("d_thresh");
-    node->get_parameter_or("d_thresh", options.trans_thresh, 0.5);
-    node->declare_parameter("a_thresh");
-    node->get_parameter_or("a_thresh", options.rot_thresh, 0.25);
-    node->declare_parameter("l2_max");
-    node->get_parameter_or("l2_max", options.l2_max, 0.5);
-    node->declare_parameter("truncate");
-    node->get_parameter_or("truncate", options.truncated_ray, 0.0);
-    node->declare_parameter("resolution");
-    node->get_parameter_or("resolution", options.resolution, 0.05);
-    node->declare_parameter("strategy");
-    node->get_parameter_or("strategy", options.strategy, std::string("gn"));
-    node->declare_parameter("use_compression");
-    node->get_parameter_or("use_compression", options.use_compression, false);
-    node->declare_parameter("compression_algorithm");
-    node->get_parameter_or("compression_algorithm", options.calgorithm, std::string("zstd"));
-    node->declare_parameter("mrange");
-    node->get_parameter_or("mrange", max_range_, 16.0);
-    node->declare_parameter("threads");
-    node->get_parameter_or("threads", options.threads, -1);
+    node->declare_parameter("srr", 0.1);
+    options.srr = node->get_parameter("srr").as_double();
+    node->declare_parameter("str", 0.2);
+    options.str = node->get_parameter("str").as_double();
+    node->declare_parameter("stt", 0.1);
+    options.stt = node->get_parameter("stt").as_double();
+    node->declare_parameter("srt", 0.2);
+    options.srt = node->get_parameter("srt").as_double();
+    node->declare_parameter("sigma", 0.05);
+    options.meas_sigma = node->get_parameter("sigma").as_double();
+    node->declare_parameter("lgain", 3.0);
+    options.meas_sigma_gain = node->get_parameter("lgain").as_double();
+    node->declare_parameter("d_thresh", 0.5);
+    options.trans_thresh = node->get_parameter("d_thresh").as_double();
+    node->declare_parameter("a_thresh", 0.25);
+    options.rot_thresh = node->get_parameter("a_thresh").as_double();
+    node->declare_parameter("l2_max", 0.5);
+    options.l2_max = node->get_parameter("l2_max").as_double();
+    node->declare_parameter("truncate", 0.0);
+    options.truncated_ray = node->get_parameter("truncate").as_double();
+    node->declare_parameter("resolution", 0.05);
+    options.resolution = node->get_parameter("resolution").as_double();
+    node->declare_parameter("strategy", "gn");
+    options.strategy = node->get_parameter("strategy").as_string();
+    node->declare_parameter("use_compression", false);
+    options.use_compression = node->get_parameter("use_compression").as_bool();
+    node->declare_parameter("compression_algorithm", "zstd");
+    options.calgorithm = node->get_parameter("compression_algorithm").as_string();
+    node->declare_parameter("mrange", 16.0);
+    max_range_ = node->get_parameter("mrange").as_double();
+    node->declare_parameter("threads", -1);
+    options.threads = node->get_parameter("threads").as_int();
 
     int itmp;
-    node->declare_parameter("patch_size");
-    node->get_parameter_or("patch_size", itmp, 32);
+    node->declare_parameter("patch_size", 32);
+    itmp = node->get_parameter("patch_size").as_int();
     options.patch_size = itmp;
-    node->declare_parameter("particles");
-    node->get_parameter_or("particles", itmp, 30);
+    node->declare_parameter("particles", 30);
+    itmp = node->get_parameter("particles").as_int();
     options.particles = itmp;
-    node->declare_parameter("cache_size");
-    node->get_parameter_or("cache_size", itmp, 100);
+    node->declare_parameter("cache_size", 100);
+    itmp = node->get_parameter("cache_size").as_int();
     options.cache_size = itmp;
     // ros param does not have unsigned int??
-    node->declare_parameter("seed");
-    node->get_parameter_or("seed", tmp, 0.0);
+    node->declare_parameter("seed", 0.0);
+    tmp = node->get_parameter("seed").as_double();
     options.seed = tmp;
 
-    node->declare_parameter("create_summary");
-    node->get_parameter_or("create_summary", options.create_summary, false);
+    node->declare_parameter("create_summary", false);
+    options.create_summary = node->get_parameter("create_summary").as_bool();
 
-    node->declare_parameter("map_publish_period");
-    node->get_parameter_or("map_publish_period", tmp, 5.0);
+    node->declare_parameter("map_publish_period", 5.0);
+    tmp = node->get_parameter("map_publish_period").as_double();
     periodic_publish_ = node->create_wall_timer(
             std::chrono::duration_cast<std::chrono::nanoseconds>(
                     std::chrono::milliseconds(static_cast<int>(tmp * 1000))),
@@ -561,9 +561,8 @@ int main(int argc, char *argv[]) {
 
     rclcpp::init(argc, argv);
     lama::PFSlam2DROS slam2d_ros {"pf_slam2d_ros"};
-    slam2d_ros.node->declare_parameter("rosbag");
-    bool using_rosbag;
-    slam2d_ros.node->get_parameter("rosbag", using_rosbag);
+    slam2d_ros.node->declare_parameter("rosbag", false);
+    bool using_rosbag = slam2d_ros.node->get_parameter("rosbag").as_bool();
     if(using_rosbag) {
         RCLCPP_INFO(slam2d_ros.node->get_logger(), "Running SLAM in Rosbag Mode (offline)");
         RCLCPP_INFO(slam2d_ros.node->get_logger(), "After the rosbag has finished, wait up to 'map_publish_period' for the map to be published. Save your map and use ctrl-c to quit.");

--- a/src/slam2d_ros.cpp
+++ b/src/slam2d_ros.cpp
@@ -40,65 +40,65 @@ lama::Slam2DROS::Slam2DROS(std::string name) :
 
     // Load parameters from the server.
     double tmp;
-    node->declare_parameter("global_frame_id");
-    node->get_parameter_or("global_frame_id", global_frame_id_, std::string("map"));
-    node->declare_parameter("odom_frame_id");
-    node->get_parameter_or("odom_frame_id", odom_frame_id_, std::string("odom"));
-    node->declare_parameter("base_frame_id");
-    node->get_parameter_or("base_frame_id", base_frame_id_, std::string("base_link"));
-    node->declare_parameter("scan_topic");
-    node->get_parameter_or("scan_topic", scan_topic_, std::string("/scan"));
-    node->declare_parameter("transform_tolerance");
-    node->get_parameter_or("transform_tolerance", tmp, 0.1);
+    node->declare_parameter("global_frame_id", "map");
+    global_frame_id_ = node->get_parameter("global_frame_id").as_string();
+    node->declare_parameter("odom_frame_id", "odom");
+    odom_frame_id_ = node->get_parameter("odom_frame_id").as_string();
+    node->declare_parameter("base_frame_id", "base_link");
+    base_frame_id_ = node->get_parameter("base_frame_id").as_string();
+    node->declare_parameter("scan_topic", "/scan");
+    scan_topic_ =  node->get_parameter("scan_topic").as_string();
+    node->declare_parameter("transform_tolerance", 0.1);
+    tmp = node->get_parameter("transform_tolerance").as_double();
     transform_tolerance_ = rclcpp::Duration::from_seconds(tmp);
 
     Vector2d pos;
-    node->declare_parameter("initial_pos_x");
-    node->get_parameter_or("initial_pos_x", pos[0], 0.0);
-    node->declare_parameter("initial_pos_y");
-    node->get_parameter_or("initial_pos_y", pos[1], 0.0);
-    node->declare_parameter("initial_pos_a");
-    node->get_parameter_or("initial_pos_a", tmp, 0.0);
+    node->declare_parameter("initial_pos_x", 0.0);
+    pos[0] = node->get_parameter("initial_pos_x").as_double();
+    node->declare_parameter("initial_pos_y", 0.0);
+    pos[1] = node->get_parameter("initial_pos_y").as_double();
+    node->declare_parameter("initial_pos_a", 0.0);
+    tmp = node->get_parameter("initial_pos_a").as_double();
     Pose2D prior(pos, tmp);
 
     Slam2D::Options options;
-    node->declare_parameter("d_thresh");
-    node->get_parameter_or("d_thresh", options.trans_thresh, 0.01);
-    node->declare_parameter("a_thresh");
-    node->get_parameter_or("a_thresh", options.rot_thresh, 0.25);
-    node->declare_parameter("l2_max");
-    node->get_parameter_or("l2_max", options.l2_max, 0.5);
-    node->declare_parameter("truncate");
-    node->get_parameter_or("truncate", options.truncated_ray, 0.0);
-    node->declare_parameter("resolution");
-    node->get_parameter_or("resolution", options.resolution, 0.05);
-    node->declare_parameter("strategy");
-    node->get_parameter_or("strategy", options.strategy, std::string("gn"));
-    node->declare_parameter("use_compression");
-    node->get_parameter_or("use_compression", options.use_compression, false);
-    node->declare_parameter("compression_algorithm");
-    node->get_parameter_or("compression_algorithm", options.calgorithm, std::string("lz4"));
-    node->declare_parameter("mrange");
-    node->get_parameter_or("mrange", max_range_, 16.0);
+    node->declare_parameter("d_thresh", 0.5);
+    options.trans_thresh = node->get_parameter("d_thresh").as_double();
+    node->declare_parameter("a_thresh", 0.25);
+    options.rot_thresh = node->get_parameter("a_thresh").as_double();
+    node->declare_parameter("l2_max", 0.5);
+    options.l2_max = node->get_parameter("l2_max").as_double();
+    node->declare_parameter("truncate", 0.0);
+    options.truncated_ray = node->get_parameter("truncate").as_double();
+    node->declare_parameter("resolution", 0.05);
+    options.resolution = node->get_parameter("resolution").as_double();
+    node->declare_parameter("strategy", "gn");
+    options.strategy = node->get_parameter("strategy").as_string();
+    node->declare_parameter("use_compression", false);
+    options.use_compression = node->get_parameter("use_compression").as_bool();
+    node->declare_parameter("compression_algorithm", "lz4");
+    options.calgorithm = node->get_parameter("compression_algorithm").as_string();
+    node->declare_parameter("mrange", 16.0);
+    max_range_ = node->get_parameter("mrange").as_double();
 
     int itmp;
-    node->declare_parameter("max_iterations");
-    node->get_parameter_or("max_iterations", itmp, 100);
+    node->declare_parameter("max_iterations", 100);
+    itmp = node->get_parameter("max_iterations").as_int();
     options.max_iter = itmp;
-    node->declare_parameter("patch_size");
-    node->get_parameter_or("patch_size", itmp, 32);
+    node->declare_parameter("patch_size", 32);
+    itmp = node->get_parameter("patch_size").as_int();
     options.patch_size = itmp;
-    node->declare_parameter("cache_size");
-    node->get_parameter_or("cache_size", itmp, 100);
+    node->declare_parameter("cache_size", 100);
+    itmp = node->get_parameter("cache_size").as_int();
     options.cache_size = itmp;
 
-    node->declare_parameter("create_summary");
-    node->get_parameter_or("create_summary", options.create_summary, false);
+    node->declare_parameter("create_summary", false);
+    options.create_summary = node->get_parameter("create_summary").as_bool();
 
     //periodic_publish_ = nh->create_wall_timer(rclcpp::Duration(tmp), std::bind(&Slam2DROS::publishCallback, this));
     // https://docs.ros2.org/beta3/api/rclcpp/classrclcpp_1_1node_1_1Node.html
-    node->declare_parameter("map_publish_period");
-    node->get_parameter_or("map_publish_period", tmp, 5.0);
+    node->declare_parameter("map_publish_period", 5.0);
+    tmp = node->get_parameter("map_publish_period").as_double();
     periodic_publish_ = node->create_wall_timer(
             std::chrono::duration_cast<std::chrono::nanoseconds>(
                     std::chrono::milliseconds(static_cast<int>(tmp * 1000))),
@@ -434,9 +434,8 @@ int main(int argc, char *argv[]) {
 
     rclcpp::init(argc, argv);
     lama::Slam2DROS slam2d_ros{"slam2d_ros"};
-    slam2d_ros.node->declare_parameter("rosbag");
-    bool using_rosbag;
-    slam2d_ros.node->get_parameter("rosbag", using_rosbag);
+    slam2d_ros.node->declare_parameter("rosbag", false);
+    bool using_rosbag = slam2d_ros.node->get_parameter("rosbag").as_bool();
     if(using_rosbag) {
         RCLCPP_INFO(slam2d_ros.node->get_logger(), "Running SLAM in Rosbag Mode (offline)");
         RCLCPP_INFO(slam2d_ros.node->get_logger(), "After the rosbag has finished, wait up to 'map_publish_period' for the map to be published. Save your map and use ctrl-c to quit.");

--- a/src/slam2d_ros.cpp
+++ b/src/slam2d_ros.cpp
@@ -403,6 +403,7 @@ void lama::Slam2DROS::publishCallback() {  // const rclcpp::TimerEvent &
 
 void lama::Slam2DROS::onGetMap(const std::shared_ptr <nav_msgs::srv::GetMap::Request> req,
                                  std::shared_ptr <nav_msgs::srv::GetMap::Response> res) {
+    static_cast<void>(req);  // To suppress compiler warning
     res->map.header.frame_id = global_frame_id_;
     res->map.header.stamp = ros_clock->now();
 

--- a/src/slam2d_ros.cpp
+++ b/src/slam2d_ros.cpp
@@ -62,7 +62,7 @@ lama::Slam2DROS::Slam2DROS(std::string name) :
     Pose2D prior(pos, tmp);
 
     Slam2D::Options options;
-    node->declare_parameter("d_thresh", 0.5);
+    node->declare_parameter("d_thresh", 0.01);
     options.trans_thresh = node->get_parameter("d_thresh").as_double();
     node->declare_parameter("a_thresh", 0.25);
     options.rot_thresh = node->get_parameter("a_thresh").as_double();


### PR DESCRIPTION
## Overview
Eliminated errors and warnings when building with ROS 2 Jazzy.

## Changes
- Replaced deprecated APIs with the latest one
- Suppressed compiler's warnings

## Future Tasks
- Support for launching SLAM nodes as composable
- Implementation of Graph SLAM (now testing on Raspberry Pi 5)